### PR TITLE
Add in a retry feature when dealing with rate limiting or other errors

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -3,6 +3,34 @@ const { exec } = require('child_process');
 // Utility function to add a 300 millisecond delay
 const delay = (ms = 300) => new Promise(resolve => setTimeout(resolve, ms));
 
+// Utility function to execute command with retry logic for 429 errors
+const execWithRetry = async (cmd, maxRetries = 5) => {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const result = await new Promise((resolve) => {
+      exec(cmd, (error, execOut, execErr) => {
+        const statusMatch = execOut.match(/HTTP_STATUS:(\d+)/);
+        const httpStatus = statusMatch ? statusMatch[1] : null;
+        resolve({ error, execOut, execErr, httpStatus });
+      });
+    });
+
+    // If not a 429 error, return the result immediately
+    if (result.httpStatus !== '429') {
+      return result;
+    }
+
+    // If it's a 429 and we have retries left, wait with exponential backoff
+    if (attempt < maxRetries - 1) {
+      const waitTime = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s, 8s, 16s
+      console.log(`Rate limited (429). Retrying in ${waitTime / 1000}s... (attempt ${attempt + 1}/${maxRetries})`);
+      await delay(waitTime);
+    } else {
+      // Last attempt failed with 429
+      return result;
+    }
+  }
+};
+
 // Utility function to process arrays in batches
 const processBatch = async (array, batchSize, processFn) => {
   for (let i = 0; i < array.length; i += batchSize) {
@@ -55,37 +83,30 @@ module.exports = async ({ core, changes, deletions, operation, siteEnv, branch, 
 
   // Process changes in batches of 5
   const processChangeFile = async (file) => {
-    return new Promise((resolve) => {
-      if (!file.endsWith('.md') && !file.endsWith('.json')) {
-        summaryData.push([`${file}`, `⚠️ Skipped`, `Only .md or .json files are allowed`]);
-        console.error(`::group:: Skipping ${file} \nOnly file types .md or .json file are allowed \n::endgroup::`);
-        resolve();
-        return;
+    if (!file.endsWith('.md') && !file.endsWith('.json')) {
+      summaryData.push([`${file}`, `⚠️ Skipped`, `Only .md or .json files are allowed`]);
+      console.error(`::group:: Skipping ${file} \nOnly file types .md or .json file are allowed \n::endgroup::`);
+      return;
+    }
+
+    // have to pop src/pages from the file path
+    const processedFile = file.replace('src/pages/', '');
+    const theFilePath = `${pathPrefix}/${processedFile}`;
+    const url = `https://admin.hlx.page/${operation}/adobedocs/${edsSiteEnv}/${codeRepoBranch}${theFilePath}`;
+    const cmd = `curl -X${httpMethod} -w "HTTP_STATUS:%{http_code}" -vif ${args} ${url}`;
+
+    const { error, execOut, execErr, httpStatus } = await execWithRetry(cmd);
+
+    if (error) {
+      if (operation.includes('preview') || operation.includes('live')) {
+        hasErrors = true;
       }
-
-      // have to pop src/pages from the file path
-      const processedFile = file.replace('src/pages/', '');
-      const theFilePath = `${pathPrefix}/${processedFile}`;
-      const url = `https://admin.hlx.page/${operation}/adobedocs/${edsSiteEnv}/${codeRepoBranch}${theFilePath}`;
-      const cmd = `curl -X${httpMethod} -w "HTTP_STATUS:%{http_code}" -vif ${args} ${url}`;
-
-      exec(cmd, (error, execOut, execErr) => {
-        // Extract HTTP status code from curl output
-        const statusMatch = execOut.match(/HTTP_STATUS:(\d+)/);
-        const httpStatus = statusMatch ? statusMatch[1] : 'Unknown';
-        if (error) {
-          if (operation.includes('preview') || operation.includes('live')) {
-            hasErrors = true;
-          }
-          summaryData.push([`${theFilePath}`, `❌ Error`, `HTTP ${httpStatus} - ${operation} failed`]);
-          console.error(`::group:: Error ${theFilePath} \nThe command: ${cmd} \n${execOut} \n${execErr} \n::endgroup::`);
-        } else {
-          summaryData.push([`${theFilePath}`, `✅ Success`, `HTTP ${httpStatus} - ${operation} completed`]);
-          console.log(`::group:: Running ${operation} on ${theFilePath} \nThe command: ${cmd} \n${execOut} \n::endgroup::`);
-        }
-        resolve();
-      });
-    });
+      summaryData.push([`${theFilePath}`, `❌ Error`, `HTTP ${httpStatus} - ${operation} failed`]);
+      console.error(`::group:: Error ${theFilePath} \nThe command: ${cmd} \n${execOut} \n${execErr} \n::endgroup::`);
+    } else {
+      summaryData.push([`${theFilePath}`, `✅ Success`, `HTTP ${httpStatus} - ${operation} completed`]);
+      console.log(`::group:: Running ${operation} on ${theFilePath} \nThe command: ${cmd} \n${execOut} \n::endgroup::`);
+    }
   };
 
   await processBatch(sortedChanges, 5, processChangeFile);
@@ -101,35 +122,27 @@ module.exports = async ({ core, changes, deletions, operation, siteEnv, branch, 
 
   // Process deletions in batches of 5
   const processDeleteFile = async (file) => {
-    return new Promise((resolve) => {
-      if (!file.endsWith('.md') && !file.endsWith('.json')) {
-        summaryData.push([`${file}`, `⚠️ Skipped`, `Only .md or .json files are allowed`]);
-        console.error(`::group:: Skipping ${file} \nOnly file types .md or .json file are allowed \n::endgroup::`);
-        resolve();
-        return;
-      }
+    if (!file.endsWith('.md') && !file.endsWith('.json')) {
+      summaryData.push([`${file}`, `⚠️ Skipped`, `Only .md or .json files are allowed`]);
+      console.error(`::group:: Skipping ${file} \nOnly file types .md or .json file are allowed \n::endgroup::`);
+      return;
+    }
 
-      // have to pop src/pages from the file path
-      const processedFile = file.replace('src/pages/', '');
-      const theFilePath = `${pathPrefix}/${processedFile}`;
-      const deleteUrl = `https://admin.hlx.page/${operation}/adobedocs/${edsSiteEnv}/${codeRepoBranch}${theFilePath}`;
-      const deleteCmd = `curl -XDELETE -w "HTTP_STATUS:%{http_code}" -vif ${args} ${deleteUrl}`;
+    // have to pop src/pages from the file path
+    const processedFile = file.replace('src/pages/', '');
+    const theFilePath = `${pathPrefix}/${processedFile}`;
+    const deleteUrl = `https://admin.hlx.page/${operation}/adobedocs/${edsSiteEnv}/${codeRepoBranch}${theFilePath}`;
+    const deleteCmd = `curl -XDELETE -w "HTTP_STATUS:%{http_code}" -vif ${args} ${deleteUrl}`;
 
-      exec(deleteCmd, (deleteError, deleteExecOut, deleteExecErr) => {
-        // Extract HTTP status code from curl output
-        const statusMatch = deleteExecOut.match(/HTTP_STATUS:(\d+)/);
-        const httpStatus = statusMatch ? statusMatch[1] : 'Unknown';
+    const { error: deleteError, execOut: deleteExecOut, execErr: deleteExecErr, httpStatus } = await execWithRetry(deleteCmd);
 
-        if (deleteError) {
-          summaryData.push([`${theFilePath}`, `❌ Error`, `HTTP ${httpStatus} - ${operation} failed`]);
-          console.error(`::group:: Deleting error ${theFilePath} \nThe command: ${deleteCmd} \n${deleteExecOut} \n${deleteExecErr} \n::endgroup::`);
-        } else {
-          summaryData.push([`${theFilePath}`, `✅ Success`, `HTTP ${httpStatus} - Delete ${operation} completed`]);
-          console.log(`::group:: Deleting ${operation} on ${theFilePath} \nThe command: ${deleteCmd} \n${deleteExecOut} \n::endgroup::`);
-        }
-        resolve();
-      });
-    });
+    if (deleteError) {
+      summaryData.push([`${theFilePath}`, `❌ Error`, `HTTP ${httpStatus} - ${operation} failed`]);
+      console.error(`::group:: Deleting error ${theFilePath} \nThe command: ${deleteCmd} \n${deleteExecOut} \n${deleteExecErr} \n::endgroup::`);
+    } else {
+      summaryData.push([`${theFilePath}`, `✅ Success`, `HTTP ${httpStatus} - Delete ${operation} completed`]);
+      console.log(`::group:: Deleting ${operation} on ${theFilePath} \nThe command: ${deleteCmd} \n${deleteExecOut} \n::endgroup::`);
+    }
   };
 
   await processBatch(sortedDeletions, 5, processDeleteFile);

--- a/deploy.js
+++ b/deploy.js
@@ -3,7 +3,7 @@ const { exec } = require('child_process');
 // Utility function to add a 300 millisecond delay
 const delay = (ms = 300) => new Promise(resolve => setTimeout(resolve, ms));
 
-// Utility function to execute command with retry logic for 429 errors
+// Utility function to execute command with retry logic for 400 and 429 errors
 const execWithRetry = async (cmd, maxRetries = 5) => {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     const result = await new Promise((resolve) => {
@@ -14,18 +14,18 @@ const execWithRetry = async (cmd, maxRetries = 5) => {
       });
     });
 
-    // If not a 429 error, return the result immediately
-    if (result.httpStatus !== '429') {
+    // If not a 400 or 429 error, return the result immediately
+    if (result.httpStatus !== '400' && result.httpStatus !== '429') {
       return result;
     }
 
-    // If it's a 429 and we have retries left, wait with exponential backoff
+    // If it's a 400 or 429 and we have retries left, wait with exponential backoff
     if (attempt < maxRetries - 1) {
       const waitTime = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s, 8s, 16s
-      console.log(`Rate limited (429). Retrying in ${waitTime / 1000}s... (attempt ${attempt + 1}/${maxRetries})`);
+      console.log(`HTTP ${result.httpStatus} error. Retrying in ${waitTime / 1000}s... (attempt ${attempt + 1}/${maxRetries})`);
       await delay(waitTime);
     } else {
-      // Last attempt failed with 429
+      // Last attempt failed with 400 or 429
       return result;
     }
   }


### PR DESCRIPTION
Sometimes the eds system will 429 when trying to upload a large amount of files. Other times it 400s a file and on a subsequent retry, the upload will work without a modification to the file.

This PR adds a retry feature with 5 max retries and with each retry adding a bit more delay in case of overloading the server. 