### PR TITLE
fix: retry on 5xx error codes

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -1,6 +1,6 @@
 const { exec } = require('child_process');
 
-const RETRYABLE_STATUS_CODES = ['400', '429'];
+const RETRYABLE_STATUS_CODES = ['400', '429', '500', '502', '503', '504'];
 
 // Utility function to add a 300 millisecond delay
 const delay = (ms = 300) => new Promise(resolve => setTimeout(resolve, ms));

--- a/deploy.js
+++ b/deploy.js
@@ -1,9 +1,11 @@
 const { exec } = require('child_process');
 
+const RETRYABLE_STATUS_CODES = ['400', '429'];
+
 // Utility function to add a 300 millisecond delay
 const delay = (ms = 300) => new Promise(resolve => setTimeout(resolve, ms));
 
-// Utility function to execute command with retry logic for 400 and 429 errors
+// Utility function to execute command with retry logic for transient errors
 const execWithRetry = async (cmd, maxRetries = 5) => {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     const result = await new Promise((resolve) => {
@@ -14,18 +16,17 @@ const execWithRetry = async (cmd, maxRetries = 5) => {
       });
     });
 
-    // If not a 400 or 429 error, return the result immediately
-    if (result.httpStatus !== '400' && result.httpStatus !== '429') {
+    if (!RETRYABLE_STATUS_CODES.includes(result.httpStatus)) {
       return result;
     }
 
-    // If it's a 400 or 429 and we have retries left, wait with exponential backoff
+    // Retryable status and we have retries left, wait with exponential backoff
     if (attempt < maxRetries - 1) {
       const waitTime = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s, 8s, 16s
       console.log(`HTTP ${result.httpStatus} error. Retrying in ${waitTime / 1000}s... (attempt ${attempt + 1}/${maxRetries})`);
       await delay(waitTime);
     } else {
-      // Last attempt failed with 400 or 429
+      // Last attempt failed with retryable status
       return result;
     }
   }


### PR DESCRIPTION
## Description
Retry on 5xx error codes

## Notes
All four 5xx status codes represent server-side errors that are typically transient and resolve on their own without any change to the request:
- 500 - Generic server error. This is what we [saw](https://adobeio.slack.com/archives/GTSGK6807/p1772130373315129?thread_ts=1772128587.233749&cid=GTSGK6807) this morning - it returned a 500 but succeeded when rerun manually.
- 502 - Invalid response from upstream. Often occurs during brief service restarts.
- 503 - Server temporarily overloaded or in maintenance.
- 504 - Upstream server timed out. Can happen intermittently due to network congestion or a slow backend.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2236

## Test
Difficult to repro `5xx` errors. However, confirmed no regression by setting up `github-actions-test` to point to this branch ([workflow](https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/.github/workflows/deploy.yml#L29), [script](https://github.com/AdobeDocs/adp-devsite-workflow/blob/test-retry-on-500-errors/.github/workflows/deploy.yml#L36)) and the [deploy](https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/22458947366/job/65047701156) ran with `4xx` retries:
<img width="1728" height="1046" alt="Screenshot 2026-02-26 at 12 02 03 PM" src="https://github.com/user-attachments/assets/325b0ede-a586-4fcd-b6d8-ef33ec6e4db4" />


