### PR TITLE
add destPath support to file-mappings for private repo workflow renaming

### DIFF
--- a/update-bot/README.md
+++ b/update-bot/README.md
@@ -53,12 +53,13 @@ An array of repos the bot will push updates to.
 
 An array of entries that describe files to add or delete in the target repos. Each entry supports two actions: **add** (default) to push a file, and **delete** to remove one.
 
-For `add` entries, the `path` refers to the file path in both the source template repo ([AdobeDocs/dev-docs-template](https://github.com/AdobeDocs/dev-docs-template)) and the target repo. The bot fetches the file from the template repo at that path and pushes it to the same path in each target repo.
+For `add` entries, `path` is the file path in the source template repo ([AdobeDocs/dev-docs-template](https://github.com/AdobeDocs/dev-docs-template)). By default the file is written to the same path in the target repo. Use `destPath` to write it to a different path — useful for private repos where workflow files have different names than their public equivalents.
 
-| Field    | Type   | Required           | Description                                                                      |
-| -------- | ------ | ------------------ | -------------------------------------------------------------------------------- |
-| `action` | string | No (default `add`) | `"add"` to create/update a file, `"delete"` to remove it                        |
-| `path`   | string | Yes                | File path in the template repo (for `add`) and in the target repo (for both)     |
+| Field      | Type   | Required           | Description                                                                                      |
+| ---------- | ------ | ------------------ | ------------------------------------------------------------------------------------------------ |
+| `action`   | string | No (default `add`) | `"add"` to create/update a file, `"delete"` to remove it                                        |
+| `path`     | string | Yes                | Source file path in the template repo (for `add`) and target path in the target repo (for both) |
+| `destPath` | string | No                 | Destination path in the target repo. Only valid for `add`. If omitted, defaults to `path`.      |
 
 #### Adding a file
 
@@ -68,6 +69,18 @@ Set `action` to `"add"` (or omit it) and provide `path`. The file is fetched fro
 {
   "action": "add",
   "path": ".github/workflows/lint.yml"
+}
+```
+
+#### Adding a file with a different destination path
+
+Use `destPath` when the file needs to land at a different path in the target repo than it has in the template. This is needed for private repos, where the `-private` workflow variants must be renamed on copy.
+
+```json
+{
+  "action": "add",
+  "path": ".github/workflows/deploy-private.yml",
+  "destPath": ".github/workflows/deploy.yml"
 }
 ```
 
@@ -82,7 +95,7 @@ Set `action` to `"delete"` and provide `path`. If the file does not exist in the
 }
 ```
 
-#### Full example
+#### Full example (private repo workflow cleanup)
 
 ```json
 [
@@ -92,7 +105,30 @@ Set `action` to `"delete"` and provide `path`. If the file does not exist in the
   },
   {
     "action": "delete",
-    "path": "dev.mjs"
+    "path": ".github/workflows/deploy.yml"
+  },
+  {
+    "action": "delete",
+    "path": ".github/workflows/stage.yml"
+  },
+  {
+    "action": "delete",
+    "path": ".github/workflows/build-auto-generated-files.yml"
+  },
+  {
+    "action": "add",
+    "path": ".github/workflows/deploy-private.yml",
+    "destPath": ".github/workflows/deploy.yml"
+  },
+  {
+    "action": "add",
+    "path": ".github/workflows/stage-private.yml",
+    "destPath": ".github/workflows/stage.yml"
+  },
+  {
+    "action": "add",
+    "path": ".github/workflows/build-auto-generated-files-private.yml",
+    "destPath": ".github/workflows/build-auto-generated-files.yml"
   }
 ]
 ```

--- a/update-bot/src/index.js
+++ b/update-bot/src/index.js
@@ -79,36 +79,38 @@ async function processRepo(repoConfig, mappings, templateContents, token) {
 
     for (const mapping of mappings) {
       const action = mapping.action ?? "add";
-      const filePath = mapping.path;
+      const srcPath = mapping.path;
+      const destPath = mapping.destPath ?? srcPath;
 
       if (action === "delete") {
-        const exists = await getContents(owner, repo, filePath, contentRef, token);
+        const exists = await getContents(owner, repo, srcPath, contentRef, token);
         if (!exists) {
-          console.log(`    [delete] ${filePath} — not found, skipping`);
-          warnings.push(`${label}: delete target not found: ${filePath}`);
+          console.log(`    [delete] ${srcPath} — not found, skipping`);
+          warnings.push(`${label}: delete target not found: ${srcPath}`);
           continue;
         }
         treeEntries.push({
-          path: filePath,
+          path: srcPath,
           mode: "100644",
           type: "blob",
           sha: null,
         });
-        console.log(`    [delete] ${filePath}`);
+        console.log(`    [delete] ${srcPath}`);
       } else {
-        const existing = await getContents(owner, repo, filePath, contentRef, token);
+        const existing = await getContents(owner, repo, destPath, contentRef, token);
         if (existing) {
-          overwrittenFiles.push(filePath);
+          overwrittenFiles.push(destPath);
         }
-        const content = templateContents.get(filePath);
+        const content = templateContents.get(srcPath);
         const blob = await createBlob(owner, repo, content, token);
         treeEntries.push({
-          path: filePath,
+          path: destPath,
           mode: "100644",
           type: "blob",
           sha: blob.sha,
         });
-        console.log(`    [${existing ? "overwrite" : "add"}] ${filePath}`);
+        const label2 = mapping.destPath ? `${srcPath} → ${destPath}` : srcPath;
+        console.log(`    [${existing ? "overwrite" : "add"}] ${label2}`);
       }
     }
 
@@ -153,12 +155,12 @@ async function processRepo(repoConfig, mappings, templateContents, token) {
       );
     }
 
-    const newFiles = addedFiles.filter((m) => !overwrittenFiles.includes(m.path));
+    const newFiles = addedFiles.filter((m) => !overwrittenFiles.includes(m.destPath ?? m.path));
     if (newFiles.length > 0) {
       prBodyParts.push(
         "",
         "### New files",
-        newFiles.map((m) => `- \`${m.path}\``).join("\n")
+        newFiles.map((m) => `- \`${m.destPath ?? m.path}\``).join("\n")
       );
     }
 

--- a/update-bot/src/validator.js
+++ b/update-bot/src/validator.js
@@ -35,7 +35,7 @@ export function validateFileMappings(mappings) {
   if (mappings.length === 0) {
     throw new Error("file-mappings.json is empty — add at least one file mapping");
   }
-  const seenPaths = new Set();
+  const seenDestPaths = new Set();
   for (const entry of mappings) {
     const action = entry.action ?? "add";
     if (!VALID_ACTIONS.includes(action)) {
@@ -46,10 +46,19 @@ export function validateFileMappings(mappings) {
     if (!entry.path || typeof entry.path !== "string") {
       throw new Error(`Invalid mapping entry: "path" must be a non-empty string. Got: ${JSON.stringify(entry)}`);
     }
-    if (seenPaths.has(entry.path)) {
-      throw new Error(`Duplicate path in file-mappings.json: ${entry.path}`);
+    if (entry.destPath !== undefined) {
+      if (action === "delete") {
+        throw new Error(`Invalid mapping entry: "destPath" is not allowed on delete entries. Got: ${JSON.stringify(entry)}`);
+      }
+      if (!entry.destPath || typeof entry.destPath !== "string") {
+        throw new Error(`Invalid mapping entry: "destPath" must be a non-empty string if provided. Got: ${JSON.stringify(entry)}`);
+      }
     }
-    seenPaths.add(entry.path);
+    const destPath = entry.destPath ?? entry.path;
+    if (seenDestPaths.has(destPath)) {
+      throw new Error(`Duplicate destination path in file-mappings.json: ${destPath}`);
+    }
+    seenDestPaths.add(destPath);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional `destPath` field to `file-mappings.json` so files can be written to a different path in the target repo than in the template - needed for private repos where `-private` workflow files must be renamed on copy (see [onboarding steps > New EDS Repo tab > step 2e](https://wiki.corp.adobe.com/spaces/AdobeCloudPlatform/pages/3547041099/Converting+and+Onboarding+to+EDS#ConvertingandOnboardingtoEDS--382725667)).

## Test

### destPath renames correctly
1. Add a private repo to `repos.json`, set `file-mappings.json` to add `deploy-private.yml` with `destPath: deploy.yml`, run `npm start`
   - <img width="911" height="223" alt="Screenshot 2026-05-11 at 1 21 57 PM" src="https://github.com/user-attachments/assets/280930e4-0d97-4c58-aa85-18adb23f9d8d" />

2. Console shows `[add] .github/workflows/deploy-private.yml → .github/workflows/deploy.yml`
   - <img width="912" height="445" alt="Screenshot 2026-05-11 at 1 22 53 PM" src="https://github.com/user-attachments/assets/b73f8623-ef08-40a5-9bb4-055a76d6fa6d" />

3. PR diff shows file at `deploy.yml`, not `deploy-private.yml`
   - <img width="1522" height="1035" alt="Screenshot 2026-05-11 at 1 23 34 PM" src="https://github.com/user-attachments/assets/442afcb9-80fa-4761-afa0-3ff29f864051" />


### No destPath still works (regression)
1. Set `file-mappings.json` to a normal entry with no `destPath`, run `npm start`
   - <img width="909" height="198" alt="Screenshot 2026-05-11 at 1 26 51 PM" src="https://github.com/user-attachments/assets/cc7df034-4f01-4f16-b8e1-fd1157156583" />
2. Console shows file path with no `→`, PR opens normally
   - <img width="911" height="472" alt="Screenshot 2026-05-11 at 1 27 05 PM" src="https://github.com/user-attachments/assets/2c86f6f0-17ee-4f2a-9036-bd2ccab1074e" />


### Validator rejects destPath on delete
1. Add a `delete` entry with `destPath` to `file-mappings.json`, run `npm start`
   - <img width="914" height="218" alt="Screenshot 2026-05-11 at 1 30 10 PM" src="https://github.com/user-attachments/assets/f038de3b-02e8-48aa-a40f-3c476d9fecc8" />
2. Error: `"destPath" is not allowed on delete entries`
   - <img width="914" height="345" alt="Screenshot 2026-05-11 at 1 30 24 PM" src="https://github.com/user-attachments/assets/29d7c6d8-6356-49a2-9419-6a71413cdd22" />

### Validator catches duplicate destination paths
1. Add two entries with the same effective destination path, run `npm start`
   - <img width="913" height="304" alt="Screenshot 2026-05-11 at 1 34 14 PM" src="https://github.com/user-attachments/assets/72835746-e240-4c80-9152-88b160655a14" />

2. Error: `Duplicate destination path in file-mappings.json`
   - <img width="916" height="337" alt="Screenshot 2026-05-11 at 1 34 28 PM" src="https://github.com/user-attachments/assets/4c8254a8-756d-4106-bbd1-683b3aa21c98" />


